### PR TITLE
Changed the way getting username works

### DIFF
--- a/Code/Commands/Fishley.Commands.RandomFish.cs
+++ b/Code/Commands/Fishley.Commands.RandomFish.cs
@@ -68,7 +68,7 @@ public partial class Fishley
 				var maxLuckTime = 60f * 60f * 48f; // 2 days
 				var luck = (int)(Math.Min((float)passed, maxLuckTime) / maxLuckTime) * 15 - (badLuck ? 1 : 0);
 				var randomAnimal = await GetRandomAnimalFromRarity(new ListSelector().SelectItem(AnimalRarities, 3 + luck, 7));
-				var embedTitle = $"{command.User.GlobalName} caught: {randomAnimal.CommonName}!";
+				var embedTitle = $"{command.User.GetUsername()} caught: {randomAnimal.CommonName}!";
 
 				var embed = new AnimalEmbedBuilder(randomAnimal, embedTitle, command.User)
 				{
@@ -151,7 +151,7 @@ public partial class Fishley
 				var user = await GetOrCreateUser(component.User.Id);
 				var MoneyToAdd = Random.Shared.Next(3, 80);
 
-				_ = await component.FollowupAsync($"Killer Fish has been greeted by **{component.User.GlobalName}**, and he is feeling **kind** today! <@{component.User.Id}> receives {NiceMoney((float)MoneyToAdd)} as a blessing gift.", ephemeral: false);
+				_ = await component.FollowupAsync($"Killer Fish has been greeted by **{component.User.GetUsername()}**, and he is feeling **kind** today! <@{component.User.Id}> receives {NiceMoney((float)MoneyToAdd)} as a blessing gift.", ephemeral: false);
 
 				user.Money = user.Money + MoneyToAdd;
 				await UpdateOrCreateUser(user);
@@ -168,7 +168,7 @@ public partial class Fishley
 				var user = await GetOrCreateUser(component.User.Id);
 				var moneyLost = user.Money / Random.Shared.Next(10, 17);
 
-				_ = await component.FollowupAsync($"Oh no! **{component.User.GlobalName}** greeted Killer Fish, but Killer Fish shows **NO FORGIVENESS**. <@{component.User.Id}> was robbed by Killer Fish and lost {NiceMoney((float)moneyLost)}...", ephemeral: false);
+				_ = await component.FollowupAsync($"Oh no! **{component.User.GetUsername()}** greeted Killer Fish, but Killer Fish shows **NO FORGIVENESS**. <@{component.User.Id}> was robbed by Killer Fish and lost {NiceMoney((float)moneyLost)}...", ephemeral: false);
 
 				user.Money = user.Money - moneyLost;
 				await UpdateOrCreateUser(user);

--- a/Code/Fishley.Moderation.cs
+++ b/Code/Fishley.Moderation.cs
@@ -31,7 +31,7 @@ public partial class Fishley
 
 		if (IsAdmin(user))
 		{
-			DebugSay($"Attempted to give warning to {user.GlobalName}({user.Id})");
+			DebugSay($"Attempted to give warning to {user.GetUsername()}({user.Id})");
 			await SendMessage(channel, $"{message} I can't warn you so please don't do it again.", reply ? socketMessage : null, 5f);
 			return;
 		}
@@ -62,7 +62,7 @@ public partial class Fishley
 
 		await UpdateOrCreateUser(storedUser);
 
-		DebugSay($"Given warning to {user.GlobalName}({user.Id})");
+		DebugSay($"Given warning to {user.GetUsername()}({user.Id})");
 		var component = new ComponentBuilder()
 			.WithButton($"Remove Warn (${warnPrice}.00)", $"fine_paid-{warnPrice}-{user.Id}", ButtonStyle.Danger)
 			.Build();
@@ -94,7 +94,7 @@ public partial class Fishley
 				break;
 		}
 
-		DebugSay($"Removed warning from {user.GlobalName}({user.Id})");
+		DebugSay($"Removed warning from {user.GetUsername()}({user.Id})");
 
 		storedUser.Warnings = Math.Max(storedUser.Warnings - 1, 0);
 		await UpdateOrCreateUser(storedUser);

--- a/Code/Fishley.OpenAI.cs
+++ b/Code/Fishley.OpenAI.cs
@@ -68,7 +68,7 @@ public partial class Fishley
 
 		var context = new List<string>();
 
-		context.Add($"[This message is sent by the user: {message.Author.GlobalName}. The user has has {storedUser.Warnings}/3 warnings. The user is the following roles: {rolesString}. The message was sent at {DateTime.UtcNow}UTC.]:");
+		context.Add($"[This message is sent by the user: {message.Author.GetUsername()}. The user has has {storedUser.Warnings}/3 warnings. The user is the following roles: {rolesString}. The message was sent at {DateTime.UtcNow}UTC.]:");
 
 		var reference = message.Reference;
 		SocketMessage reply = null;

--- a/Code/Util/Extensions/DiscordIUserExtensions.cs
+++ b/Code/Util/Extensions/DiscordIUserExtensions.cs
@@ -1,0 +1,7 @@
+﻿namespace Fishley
+{
+    public static class DiscordIUserExtensions
+    {
+        public static string GetUsername(this IUser user) => user.GlobalName != null ? user.GlobalName : user.Username;
+    }
+}


### PR DESCRIPTION
The thing about **User.GlobalName** is that it only works if you have a Display Name, if you don't, it leaves you with a null string.
So you could quite easily get into the situation where a person without Display Name wouldn't show up at all

### (How does it affect Fishley?):
- When you catch a fish, it just says "caught: " and not "username caught: "
- When you ask it a question about your username, it gives you an empty result.

So with this change, hopefully, it gets your discord's username even if you have empty Display Name